### PR TITLE
Refactor `byte` => `UInt8`

### DIFF
--- a/src/LeanEVM/State.lean
+++ b/src/LeanEVM/State.lean
@@ -1,4 +1,4 @@
-import LeanEVM.Util.Int
+import LeanEVM.Util.UInt
 
 /- =============================================================== -/
 /- Bytecodes -/
@@ -20,9 +20,9 @@ inductive Bytecode where
 -- 60s & 70s: Push Operations
 | Push(bs:Bytes32)
 -- 80s: Duplication Operations
-| Dup(n:u4)
+| Dup(n:UInt4)
 -- 90s: Exchange Operations
-| Swap(n:u4)
+| Swap(n:UInt4)
 -- a0s: Logging Operations
 -- f0s: System operations
 | Invalid
@@ -34,14 +34,14 @@ inductive Bytecode where
 
 def MAX_CODE_SIZE := 24576
 
-def EvmCode := Array u8
+def EvmCode := Array UInt8
 
 -- Read a byte at a given `pc` position within a code sequence.  If the position
 -- is out-of-bounds, then `0` is returned.
-def EvmCode.read(st:EvmCode)(pc:Nat) : u8 :=
+def EvmCode.read(st:EvmCode)(pc:Nat) : UInt8 :=
   if r:pc >= st.size
   then
-    U8_0
+    0
   else
     st.get {val:=pc,isLt:=(by omega)}
 
@@ -52,7 +52,7 @@ def EvmCode.slice(st:EvmCode)(pc:Nat)(n:Nat) : Bytes32 :=
 -- Decode the instruction at a given `pc` position within the code sequence.
 def EvmCode.decode (st:EvmCode)(pc:Nat) : Bytecode :=
   -- Read opcode
-  let opcode : u8 := st.read pc;
+  let opcode := st.read pc;
   -- Decode opcode
   match opcode.val with
   -- 0s: Stop and Arithmetic Operations
@@ -109,7 +109,7 @@ def EvmCode.decode (st:EvmCode)(pc:Nat) : Bytecode :=
 /- =============================================================== -/
 /- Stack -/
 /- =============================================================== -/
-def EvmStack := List u256
+def EvmStack := List UInt256
 
 -- Pop an item of the EVM stack
 @[simp] def EvmStack.pop (st:EvmStack)(n:Nat)(r:n <= st.length) : EvmStack :=
@@ -125,15 +125,15 @@ def EvmStack := List u256
   | [] => []
 
 -- Push an item onto the EVM stack
-@[simp] def EvmStack.push (st:EvmStack)(n:u256) : EvmStack :=
+@[simp] def EvmStack.push (st:EvmStack)(n:UInt256) : EvmStack :=
   n::st
 
 -- Peek an item on the EVM stack
-@[simp] def EvmStack.peek (st:EvmStack)(i:Fin st.length) : u256 :=
+@[simp] def EvmStack.peek (st:EvmStack)(i:Fin st.length) : UInt256 :=
   st.get i
 
 -- Assign an item v to the ith position in the EVM stack
-@[simp] def EvmStack.set (st:EvmStack)(n:u256)(i:Fin st.length) : EvmStack :=
+@[simp] def EvmStack.set (st:EvmStack)(n:UInt256)(i:Fin st.length) : EvmStack :=
   List.set st i n
 
 /- =============================================================== -/
@@ -146,13 +146,13 @@ structure Evm where
 @[simp] def Evm.pop (evm:Evm)(n:Nat)(r:n <= evm.stack.length) : Evm :=
   {stack := evm.stack.pop n r}
 
-@[simp] def Evm.push (evm:Evm)(n:u256) : Evm :=
+@[simp] def Evm.push (evm:Evm)(n:UInt256) : Evm :=
   {stack:=evm.stack.push n}
 
-@[simp] def Evm.peek (evm:Evm)(n:Nat)(r:n < evm.stack.length) : u256 :=
+@[simp] def Evm.peek (evm:Evm)(n:Nat)(r:n < evm.stack.length) : UInt256 :=
   evm.stack.peek { val:= n, isLt := r}
 
-@[simp] def Evm.set (evm:Evm)(n:Nat)(v:u256)(r:n < evm.stack.length) : Evm :=
+@[simp] def Evm.set (evm:Evm)(n:Nat)(v:UInt256)(r:n < evm.stack.length) : Evm :=
   {stack:=evm.stack.set v { val:= n, isLt := r}}
 
 def EmptyEvm : Evm := {stack:=[]}

--- a/src/LeanEVM/Util/Bytes.lean
+++ b/src/LeanEVM/Util/Bytes.lean
@@ -1,11 +1,8 @@
 import LeanEVM.Util.FinVec
 import LeanEVM.Util.Lemmas
 
-def byte := Fin 256
-
-def Bytes32 := FinVec (n:=32) byte
-
-opaque BYTE_0 : byte := {val:=0, isLt:=(by simp)}
+-- An array of (at most) 32 bytes.
+def Bytes32 := FinVec (n:=32) UInt8
 
 -- ==================================================================================
 -- From Bytes (little endian)
@@ -13,17 +10,17 @@ opaque BYTE_0 : byte := {val:=0, isLt:=(by simp)}
 
 -- Construct a natural number from a sequence of one or more bytes stored in little
 -- endian form.
-def from_bytes_le(bytes:List byte) : Nat :=
+def from_bytes_le(bytes:List UInt8) : Nat :=
   match bytes with
   | List.nil => 0
   | b::bs =>
-      (256 * (from_bytes_le bs)) + b.val
+      (256 * (from_bytes_le bs)) + b.toNat
 
 -- Bound the number returned by `from_bytes_le`.  For example, if one byte is
 -- passed into `from_bytes_le` then the return value is bounded by `256`;
 -- likewise, if two bytes are passed into `from_bytes_le` then the return value
 -- is bounded by `65536`, etc.
-def from_bytes_le_bound(n:Nat)(bytes:List byte)(p:bytes.length ≤ n) : (from_bytes_le bytes) < 256^n :=
+def from_bytes_le_bound(n:Nat)(bytes:List UInt8)(p:bytes.length ≤ n) : (from_bytes_le bytes) < 256^n :=
 by
   match n,bytes with
   | 0, [] => unfold from_bytes_le; simp
@@ -38,16 +35,17 @@ by
       unfold from_bytes_le
       apply (pow256_shift (from_bytes_le bs) b k r)
 
-example (n:byte): (from_bytes_le [n]) = n.val :=
+example (n:UInt8): (from_bytes_le [n]) = n.val :=
 by
   repeat unfold from_bytes_le
   simp
+  rfl
 
-example (n:byte): (from_bytes_le [n, Fin.ofNat 0]) = n.val :=
+example (n:UInt8): (from_bytes_le [n, 0]) = n.val :=
 by
   repeat unfold from_bytes_le
-  unfold Fin.ofNat
   simp
+  rfl
 
 -- ==================================================================================
 -- From Bytes (big endian)
@@ -55,27 +53,27 @@ by
 
 -- Construct a natural number from a sequence of one or more bytes stored in big
 -- endian form.
-def from_bytes_be(bytes:List byte) : Nat :=
+def from_bytes_be(bytes:List UInt8) : Nat :=
   from_bytes_le (List.reverse bytes)
 
 -- Bound the number returned by `from_bytes_be`.  For example, if one byte is
 -- passed into `from_bytes_le` then the return value is bounded by `256`;
 -- likewise, if two bytes are passed into `from_bytes_be` then the return value
 -- is bounded by `65536`, etc.
-def from_bytes_be_bound(n:Nat)(bytes:List byte)(p:bytes.length ≤ n) : (from_bytes_be bytes) < 256^n :=
+def from_bytes_be_bound(n:Nat)(bytes:List UInt8)(p:bytes.length ≤ n) : (from_bytes_be bytes) < 256^n :=
 by
   sorry
 
-example (n:byte): (from_bytes_be [n]) = n.val :=
+example (n:UInt8): (from_bytes_be [n]) = n.val :=
 by
   unfold from_bytes_be
-  simp
   repeat unfold from_bytes_le
   simp
+  rfl
 
-example (n:byte): (from_bytes_be [Fin.ofNat 0, n]) = n.val :=
+example (n:UInt8): (from_bytes_be [0, n]) = n.val :=
 by
   unfold from_bytes_be
   repeat simp; unfold from_bytes_le
-  unfold Fin.ofNat
+  unfold UInt8.toNat
   simp_arith

--- a/src/LeanEVM/Util/Lemmas.lean
+++ b/src/LeanEVM/Util/Lemmas.lean
@@ -7,8 +7,8 @@ by
   exact Nat.mul_le_mul_left m p
 
 -- A simple proof for "left shifting" bytes.  This could no doubt be generalised.
-def pow256_shift(n:Nat)(m:Fin 256)(k:Nat)(p:n < 256^k) : (256*n + m.val < 256^(k+1)) :=
+def pow256_shift(n:Nat)(m:UInt8)(k:Nat)(p:n < 256^k) : (256*n + m.val < 256^(k+1)) :=
 by
   have s : 256*n + 256 ≤ 256^(k+1) := (pow_shift n 256 k p)
-  have r : 256*n + m.val < 256*n + 256 := by exact Fin.natAdd.proof_1 (256 * n) m
+  have r : 256*n + m.val < 256*n + 256 := by exact Fin.natAdd.proof_1 (256 * n) m.val
   exact Nat.lt_of_lt_of_le r s

--- a/src/LeanEVM/Util/UInt.lean
+++ b/src/LeanEVM/Util/UInt.lean
@@ -4,14 +4,7 @@ import LeanEVM.Util.Bytes
 /- Constants -/
 /- =============================================================== -/
 
-def u4 := Fin 16
-
-/- =============================================================== -/
-/- U8 -/
-/- =============================================================== -/
-
-def u8 := Fin 256
-opaque U8_0 : u8 := {val:=0, isLt:=(by simp)}
+def UInt4 := Fin 16
 
 /- =============================================================== -/
 /- U256 -/
@@ -19,34 +12,34 @@ opaque U8_0 : u8 := {val:=0, isLt:=(by simp)}
 
 def TWO_256 := 0x10000000000000000000000000000000000000000000000000000000000000000
 
-def u256 := Fin TWO_256
+def UInt256 := Fin TWO_256
 
-def u256.from_bytes(bytes: Bytes32) : u256 :=
+def UInt256.from_bytes(bytes: Bytes32) : UInt256 :=
   -- Convert bytes into nat
   let n := from_bytes_be bytes.data;
   -- Bound size of n using lemma
   have q : n < 256^32 := (from_bytes_be_bound 32 bytes.data bytes.isLt)
-  -- Convert nat into u256
+  -- Convert nat into UInt256
   {val:=n, isLt:=q}
 
-def u256.add (i:u256)(j: u256) : u256 :=
+def UInt256.add (i:UInt256)(j: UInt256) : UInt256 :=
   Fin.add i j
 
-def u256.sub (i:u256)(j: u256) : u256 :=
+def UInt256.sub (i:UInt256)(j: UInt256) : UInt256 :=
   Fin.sub i j
 
-def u256.mul (i:u256)(j: u256) : u256 :=
+def UInt256.mul (i:UInt256)(j: UInt256) : UInt256 :=
   Fin.mul i j
 
-def u256.div (i:u256)(j: u256) : u256 :=
+def UInt256.div (i:UInt256)(j: UInt256) : UInt256 :=
   Fin.div i j
 
-def U256_0 : u256 := {val:=0, isLt:=(by simp_arith)}
-def U256_1 : u256 := {val:=1, isLt:=(by simp_arith)}
-def U256_2 : u256 := {val:=2, isLt:=(by simp_arith)}
-def U256_3 : u256 := {val:=3, isLt:=(by simp_arith)}
-def U256_4 : u256 := {val:=4, isLt:=(by simp_arith)}
-def U256_MAX : u256 := {val:=TWO_256 - 1, isLt:=(by simp_arith)}
+def U256_0 : UInt256 := {val:=0, isLt:=(by simp_arith)}
+def U256_1 : UInt256 := {val:=1, isLt:=(by simp_arith)}
+def U256_2 : UInt256 := {val:=2, isLt:=(by simp_arith)}
+def U256_3 : UInt256 := {val:=3, isLt:=(by simp_arith)}
+def U256_4 : UInt256 := {val:=4, isLt:=(by simp_arith)}
+def U256_MAX : UInt256 := {val:=TWO_256 - 1, isLt:=(by simp_arith)}
 
 /- =============================================================== -/
 /- Helpers -/
@@ -76,9 +69,9 @@ by
 
 -- Simple demonstration that a singleton byte array returns its only byte as the
 -- result.
-example (n:byte)(bs:Bytes32)(p:bs.data=[n]): (u256.from_bytes bs).val = n.val :=
+example (n:UInt8)(bs:Bytes32)(p:bs.data=[n]): (UInt256.from_bytes bs).val = n.val :=
 by
-  unfold u256.from_bytes
+  unfold UInt256.from_bytes
   simp
   repeat unfold from_bytes_be
   --simp_arith

--- a/src/Main.lean
+++ b/src/Main.lean
@@ -6,3 +6,12 @@ import LeanEVM.State
 
 def main : IO Unit :=
   IO.println "Hello world"
+
+
+abbrev byte2 := Fin 256
+
+def test(n:List byte2) := n.length
+
+example : (test [1,2]) = 2 :=
+by
+  simp_arith


### PR DESCRIPTION
This also refactors a few other similar things.  For example, `u4` becomes `UInt4` and `u256` because `UInt256` to keep the naming consistent.